### PR TITLE
Implemented provisioned concurrency

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,3 @@
+**/__pycache__
+.venv
+.ruff_cache

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,23 @@
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.13
+
+WORKDIR /var/task
+
+RUN mkdir -p /opt/extensions
+
+COPY --from=public.ecr.aws/awsguru/aws-lambda-adapter:0.9.1 /lambda-adapter /opt/extensions/lambda-adapter
+
+ENV UV_NO_CACHE=1
+ENV UV_INSTALL_DIR=/usr/local/bin
+ENV MPLCONFIGDIR=/var/task/.config/matplotlib
+
+RUN dnf update -y && dnf install graphviz tar gzip -y
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+COPY pyproject.toml .python-version uv.lock ./
+
+RUN uv export --frozen --no-emit-workspace --no-dev --no-editable -o requirements.txt
+RUN python -m pip install -r requirements.txt -t .
+
+COPY . .
+
+ENTRYPOINT ["python", "-m", "uvicorn", "--port=8080", "main:app"]

--- a/api/run.sh
+++ b/api/run.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
-    PYTHONPATH=$PYTHONPATH:/opt/python:$LAMBDA_RUNTIME_DIR \
-    exec python -m uvicorn --port=$PORT main:app

--- a/cdk/eslint.config.mjs
+++ b/cdk/eslint.config.mjs
@@ -3,7 +3,6 @@ import tsEslint from 'typescript-eslint';
 import cdkPlugin from 'eslint-cdk-plugin';
 
 export default tsEslint.config(
-  // ESLintの推奨設定を適用
   eslint.configs.recommended,
   ...tsEslint.configs.recommended,
   {

--- a/cdk/parameter.template.ts
+++ b/cdk/parameter.template.ts
@@ -48,4 +48,10 @@ export const parameter: Parameter = {
 
   // AgentCore configuration
   agentCoreRegion: 'us-east-1',
+
+  // Provisioned concurrency configuration for Lambda function
+  // Set the number of concurrent executions to keep warm (0-1000)
+  // Default: 10 concurrent executions to minimize cold start latency
+  // Set to 0 to disable provisioned concurrency
+  provisionedConcurrency: 10,
 };

--- a/cdk/parameter.types.ts
+++ b/cdk/parameter.types.ts
@@ -11,4 +11,5 @@ export interface Parameter {
   novaCanvasRegion: string;
   createTitleModel: Omit<Model, 'displayName'>;
   agentCoreRegion: string;
+  provisionedConcurrency: number;
 }


### PR DESCRIPTION
Since the 250MB size limit for Lambda is restrictive in PythonFunction, we migrated to DockerImageFunction. Because SnapStart cannot be used with DockerImageFunction, we made it possible to configure Provisioned Concurrency. The default value is 10.